### PR TITLE
BUG fix. Initilize the private folder at top

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,6 +3,8 @@ set -euo pipefail
 
 initialized=/var/.samba-initialized
 
+mkdir -p /var/lib/samba/private
+
 if [ ! -e "$initialized" ]; then
   if [ -e /scripts/one-time-init.sh ]; then
     sh -euo pipefail /scripts/one-time-init.sh
@@ -24,8 +26,6 @@ fi
 if [ "${AVAHI_ENABLED:-}" != "false" ]; then
   { while true; do avahi-daemon || true; done } &
 fi
-
-mkdir -p /var/lib/samba/private
 
 nmbd -D
 exec smbd -F --no-process-group </dev/null


### PR DESCRIPTION
If the folder is not initilize at the top and the private does not exist. Then creating and change password of users inside a one-time-init.sh script will fail.